### PR TITLE
node.js 12.16.1 to fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/react-file-input
   docker:
-    - image: circleci/node:13.8-stretch
+    - image: circleci/node:12.16.1-stretch
 
 whitelist: &whitelist
   paths:


### PR DESCRIPTION
it's strange that in that PR https://github.com/brainhubeu/react-file-input/pull/46 build passed with Node.js v13 but after merging it failed and fails each time.